### PR TITLE
76 get codecov to run

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
         run: uv sync --locked --all-extras --dev
 
       - name: Run tests
-        run: uv run pytest --cov --cov-branch --cov-report=xml tests
+        run: uv run pytest --cov=. --cov-branch --cov-report=xml tests
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ o.prof
 o.folded
 __pycache__/ # Python bytecode
 quality_control/
-
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,6 @@ src/home_coords.py
 plots/
 o.prof
 o.folded
-__pycache__/ # Python bytecode
+**/__pycache__/ # Python bytecode
 quality_control/
 coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![codecov](https://codecov.io/gh/<ORG>/<REPO>/branch/main/graph/badge.svg)](https://codecov.io/gh/<ORG>/<REPO>)
+
 # Investigating Cat Movement Patterns 
 
 ## Project goals


### PR DESCRIPTION
I added '=.' to the following line: uv run pytest --cov=. --cov-report=term-missing
I also added the batch.
After merging this change and running it on the main branch a reference is generated, against which the future PRs can be compared against.
Hopefully, the display will work correctly now.                                                     